### PR TITLE
Remove render_manager->priv->zoomed check

### DIFF
--- a/src/home/hd-render-manager.c
+++ b/src/home/hd-render-manager.c
@@ -3397,7 +3397,6 @@ hd_render_manager_press_effect (void)
     HdRenderManagerPrivate *priv = render_manager->priv;
 
     g_return_if_fail (render_manager != NULL);
-    g_return_if_fail (!render_manager->priv->zoomed);
 
     if (!priv->press_effect)  
     {


### PR DESCRIPTION
This fixes compilation without G_DISABLE_CHECKS defined. That line seems to be leftover from global zoom support (commit fd73e4f), which was removed.